### PR TITLE
Pulling up-to-date Frotz source

### DIFF
--- a/gnusto-frotz-tops20
+++ b/gnusto-frotz-tops20
@@ -22,12 +22,13 @@ use warnings;
 
 use Cwd;
 use File::Path qw(rmtree);
+use File::Copy;
 
-#our $FROTZREPO="https://gitlab.com/DavidGriffith/frotz.git";
+our $FROTZREPO="https://gitlab.com/DavidGriffith/frotz.git";
 #our $FROTZTAG="dumb-2.32r1";
-
-our $FROTZREPO="https://github.com/athornton/tops20-frotz.git";
-our $FROTZTAG="unix";
+our $FROTZTAG="master";
+our $FROTZCOMMON="src/common";
+our $FROTZDUMB="src/dumb";
 
 our %symbolmap = ();
 our $counter = 0;
@@ -56,11 +57,26 @@ sub the_whole_enchilada {
 sub fetch_sources {
     chdir $topdir;
     if ( ! -d $srcdir ) {
-	`git clone $FROTZREPO $srcdir`;
+	`git clone --depth 1 --no-checkout --filter=blob:none $FROTZREPO $srcdir`;
     }
     chdir $srcdir;
-    `git checkout $FROTZTAG`;
+    `git checkout $FROTZTAG -- $FROTZCOMMON`;
+    `git checkout $FROTZTAG -- $FROTZDUMB`;
     `git pull`;
+
+    my @subdirs = glob "$srcdir/src/*";
+    my @files;
+
+    foreach my $dir (@subdirs) {
+	push(@files, glob "$dir/*.c");
+	push(@files, glob "$dir/*.h");
+    }
+
+    foreach my $file (@files) {
+	move($file, $srcdir);
+    }
+
+    rmtree("$srcdir/src");
     chdir $topdir;
 }
 

--- a/gnusto-frotz-tops20
+++ b/gnusto-frotz-tops20
@@ -189,8 +189,16 @@ sub shorten_filenames {
 	(my $new = $f) =~ s/dumb-/d/;
 	rename $f,$new;
     }
+    # do it again for 'dumb_'
+    @files=glob("dumb_*");
+    for my $f (@files) {
+	(my $new = $f) =~ s/dumb_/d/;
+	rename $f,$new;
+    }
     # Fix up includes
     `sed $sedinplace s/dumb-frotz.h/dfrotz.h/ *.c`;
+    `sed $sedinplace s/dumb_frotz.h/dfrotz.h/ *.c`;
+    `sed $sedinplace s/dumb_blorb.h/dblorb.h/ *.c`;
     # Now make them a maximum of six characters before the .c
     my %collision=();
     @files=glob("*.c"); # We already know the .h files are OK.


### PR DESCRIPTION
The first of these commits will allow a pull to be made from after Dumb Frotz was incorporated into the Frotz codebase.  The second adds some file-shortening code to account for substitution of an underscore for a dash in filenames and account for ````dumb_blorb.h````.