### PR TITLE
Don't get overzealous with matching symbols.

### DIFF
--- a/gnusto-frotz-tops20
+++ b/gnusto-frotz-tops20
@@ -185,7 +185,7 @@ sub create_sed_file {
     for my $k (reverse(sort(keys %symbolmap))) {
 	my $symbol = $symbolmap{$k}{'original'};
 	my $newsym = $symbolmap{$k}{'new'};
-	print $ofh "s/$symbol/$newsym/g\n";
+	print $ofh "s/$symbol(?!\\w)/$newsym/g\n";
     }
 }
 	    


### PR DESCRIPTION
This avoids problems with matching "interpreter" when you're just
looking for "interpret".