### PR TITLE
Limit matches to whole words the Right Way.

### DIFF
--- a/gnusto-frotz-tops20
+++ b/gnusto-frotz-tops20
@@ -185,7 +185,7 @@ sub create_sed_file {
     for my $k (reverse(sort(keys %symbolmap))) {
 	my $symbol = $symbolmap{$k}{'original'};
 	my $newsym = $symbolmap{$k}{'new'};
-	print $ofh "s/$symbol(?!\\w)/$newsym/g\n";
+	print $ofh "s/\\b$symbol\\b/$newsym/g\n";
     }
 }
 	    


### PR DESCRIPTION
I forgot to double-check 197cfa25af6a035e27fdae8f1e3abf2c7ea4f8ed which would have shown me sed doesn't like that particular way of doing a regex.  This one is correct.